### PR TITLE
Add core engine traits, backtest module, and helper functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,10 +39,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
+name = "async-trait"
+version = "0.1.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "backtrace"
+version = "0.3.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets",
+]
 
 [[package]]
 name = "bitflags"
@@ -46,6 +87,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cc"
@@ -89,11 +136,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
+
+[[package]]
 name = "destiny-engine"
 version = "1.0.0"
 dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "derive_builder",
  "destiny-helpers",
  "destiny-types",
+ "tokio",
 ]
 
 [[package]]
@@ -116,6 +234,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,6 +249,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "homedir"
@@ -162,6 +292,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,10 +314,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+
+[[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
 
 [[package]]
 name = "nix"
@@ -205,10 +377,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "ppv-lite86"
@@ -268,10 +478,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
 name = "rustversion"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -300,6 +531,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "socket2"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,6 +570,35 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tokio"
+version = "1.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -466,6 +757,15 @@ name = "windows-result"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
 snowflaked = { version = "1", features = ["sync"] }
 async-trait = { version = "0.1" }
-parking_lot = { version = "0.12" }
-ringbuffer = { version = "0.15" }
 uuid = { version = "1", features = ["v4", "fast-rng", "macro-diagnostics"] }
 num_cpus = { version = "1" }
 homedir = { version = "0.3" }
 polars = { version = "0.46" }
+derive_builder = { version = "0.20" }

--- a/destiny-engine/Cargo.toml
+++ b/destiny-engine/Cargo.toml
@@ -11,3 +11,8 @@ readme.workspace = true
 [dependencies]
 destiny-helpers = { workspace = true }
 destiny-types = { workspace = true }
+async-trait = { workspace = true }
+anyhow = { workspace = true }
+chrono = { workspace = true }
+tokio = { workspace = true }
+derive_builder = { workspace = true }

--- a/destiny-engine/src/backtest.rs
+++ b/destiny-engine/src/backtest.rs
@@ -1,0 +1,80 @@
+use std::sync::Arc;
+
+use crate::traits::*;
+use anyhow::{ensure, Result};
+use async_trait::async_trait;
+use chrono::{DateTime, Duration, DurationRound, Utc};
+use derive_builder::Builder;
+use destiny_helpers::num::{is_zero, truncate_float};
+
+#[derive(Builder)]
+#[builder(setter(into))]
+pub struct BacktestConfig {
+    pub begin: DateTime<Utc>,
+    pub end: DateTime<Utc>,
+    #[builder(default = 1000.)]
+    pub spot_balance: f64,
+    #[builder(default = 1000.)]
+    pub contract_balance: f64,
+    #[builder(default = 0.0005)]
+    pub taker_fee_rate: f64,
+    #[builder(default = 0.0005)]
+    pub maker_fee_rate: f64,
+    #[builder(default = 0.01)]
+    pub slippage_rate: f64,
+}
+
+#[allow(dead_code)]
+pub struct Backtest {
+    config: Arc<BacktestConfig>,
+}
+
+#[async_trait]
+impl Engine for Backtest {}
+
+fn new(mut config: BacktestConfig) -> Result<Arc<Backtest>> {
+    config.begin = config.begin.duration_trunc(Duration::minutes(1))?;
+    config.end = config.end.duration_trunc(Duration::minutes(1))?;
+    ensure!(
+        config.begin < config.end,
+        "begin time must be less than end time"
+    );
+
+    config.spot_balance = truncate_float(config.spot_balance, 8, false);
+    ensure!(
+        config.spot_balance >= 0.0,
+        "spot balance must be greater than 0"
+    );
+
+    config.contract_balance = truncate_float(config.contract_balance, 8, false);
+    ensure!(
+        config.contract_balance >= 0.0,
+        "contract balance must be greater than 0"
+    );
+
+    ensure!(
+        !(is_zero(config.spot_balance) && is_zero(config.contract_balance)),
+        "spot balance and contract balance must not be both 0"
+    );
+
+    config.taker_fee_rate = truncate_float(config.taker_fee_rate, 8, false);
+    config.maker_fee_rate = truncate_float(config.maker_fee_rate, 8, false);
+
+    config.slippage_rate = truncate_float(config.slippage_rate, 8, false);
+    ensure!(
+        config.slippage_rate >= 0.0,
+        "slippage rate must be greater than 0"
+    );
+
+    Ok(Arc::new(Backtest {
+        config: Arc::new(config),
+    }))
+}
+
+pub async fn run(config: BacktestConfig, strategy: Arc<dyn Strategy>) -> Result<()> {
+    let backtest = new(config)?;
+    strategy.on_init(backtest.clone()).await?;
+    strategy.on_start(backtest.clone()).await?;
+    strategy.on_stop(backtest.clone()).await?;
+    Ok(())
+}

--- a/destiny-engine/src/lib.rs
+++ b/destiny-engine/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod backtest;
 pub mod prelude;
 pub mod traits;

--- a/destiny-engine/src/prelude.rs
+++ b/destiny-engine/src/prelude.rs
@@ -1,1 +1,7 @@
-pub use crate::traits::*;
+pub use crate::{
+    backtest::{
+        run as run_backtest, Backtest, BacktestConfig, BacktestConfigBuilder,
+        BacktestConfigBuilderError,
+    },
+    traits::*,
+};

--- a/destiny-engine/src/traits.rs
+++ b/destiny-engine/src/traits.rs
@@ -1,3 +1,80 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use destiny_helpers::prelude::*;
+use std::sync::Arc;
 
+#[async_trait]
+pub trait Engine: Send + Sync {
+    fn ms_to_date(&self, ms: i64) -> Result<DateTime<Utc>> {
+        ms_to_date(ms)
+    }
 
+    fn now_ms(&self) -> i64 {
+        now_ms()
+    }
 
+    fn now(&self) -> DateTime<Utc> {
+        now()
+    }
+
+    fn gen_id(&self) -> String {
+        gen_id()
+    }
+
+    fn truncate_float(&self, val: f64, decimals: u32, round_up: bool) -> f64 {
+        truncate_float(val, decimals, round_up)
+    }
+
+    fn is_zero(&self, val: f64) -> bool {
+        is_zero(val)
+    }
+}
+
+#[async_trait]
+#[allow(unused_variables)]
+pub trait Strategy: Send + Sync {
+    async fn on_init(&self, engine: Arc<dyn Engine>) -> Result<()> {
+        Ok(())
+    }
+
+    async fn on_start(&self, engine: Arc<dyn Engine>) -> Result<()> {
+        Ok(())
+    }
+
+    async fn on_stop(&self, engine: Arc<dyn Engine>) -> Result<()> {
+        Ok(())
+    }
+
+    async fn on_daily(&self, engine: Arc<dyn Engine>) -> Result<()> {
+        Ok(())
+    }
+
+    async fn on_hourly(&self, engine: Arc<dyn Engine>) -> Result<()> {
+        Ok(())
+    }
+
+    async fn on_minutely(&self, engine: Arc<dyn Engine>) -> Result<()> {
+        Ok(())
+    }
+
+    async fn on_secondly(&self, engine: Arc<dyn Engine>) -> Result<()> {
+        Ok(())
+    }
+
+    async fn on_tick(&self, engine: Arc<dyn Engine>) -> Result<()> {
+        Ok(())
+    }
+
+    async fn on_order(&self, engine: Arc<dyn Engine>) -> Result<()> {
+        Ok(())
+    }
+
+    async fn on_market(&self, engine: Arc<dyn Engine>) -> Result<()> {
+        Ok(())
+    }
+
+    async fn on_account(&self, engine: Arc<dyn Engine>) -> Result<()> {
+        Ok(())
+    }
+}

--- a/destiny-engine/tests/backtest.rs
+++ b/destiny-engine/tests/backtest.rs
@@ -1,0 +1,37 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use destiny_engine::prelude::*;
+use destiny_helpers::prelude::*;
+use std::sync::Arc;
+
+struct BacktestStrategy;
+
+#[async_trait]
+#[allow(unused_variables)]
+impl Strategy for BacktestStrategy {
+    async fn on_init(&self, engine: Arc<dyn Engine>) -> Result<()> {
+        println!("on_init: {}", engine.now_ms());
+        Ok(())
+    }
+
+    async fn on_start(&self, engine: Arc<dyn Engine>) -> Result<()> {
+        println!("on_start: {}", engine.now_ms());
+        Ok(())
+    }
+
+    async fn on_stop(&self, engine: Arc<dyn Engine>) -> Result<()> {
+        println!("on_stop: {}", engine.now_ms());
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn test_backtest() -> Result<()> {
+    let config = BacktestConfigBuilder::default()
+        .begin(str_to_date("2024-01-01T00:00:00Z")?)
+        .end(str_to_date("2024-01-02T00:00:00Z")?)
+        .build()?;
+
+    run_backtest(config, Arc::new(BacktestStrategy)).await?;
+    Ok(())
+}

--- a/destiny-helpers/src/date.rs
+++ b/destiny-helpers/src/date.rs
@@ -14,3 +14,9 @@ pub fn now_ms() -> i64 {
 pub fn now() -> DateTime<Utc> {
     Utc::now()
 }
+
+pub fn str_to_date(s: &str) -> Result<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(s)
+        .map(|d| d.to_utc())
+        .map_err(|e| anyhow!("convert str to date failed: {}", e))
+}

--- a/destiny-helpers/src/id.rs
+++ b/destiny-helpers/src/id.rs
@@ -3,3 +3,4 @@ use uuid::Uuid;
 pub fn gen_id() -> String {
     Uuid::new_v4().to_string().replace("-", "")
 }
+


### PR DESCRIPTION
This commit introduces several key components to the Destiny Engine:
- Added core `Engine` and `Strategy` traits with async methods
- Created a new `backtest` module for backtesting functionality
- Expanded helper functions in `date.rs` and `id.rs`
- Updated dependencies to support new engine features