### PR TITLE
ci: Add Cargo caching to Rust GitHub Actions workflows

### DIFF
--- a/.github/workflows/rust-clippy-check.yml
+++ b/.github/workflows/rust-clippy-check.yml
@@ -23,7 +23,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-rust-clippy-check
+          key: ${{ runner.os }}-rust-clippy-check-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-rust-clippy-check-${{ hashFiles('**/Cargo.lock') }}
       - name: rust-clippy-check
         run: cargo +nightly clippy --all-targets --all-features --tests -- -Dwarnings

--- a/.github/workflows/rust-clippy-check.yml
+++ b/.github/workflows/rust-clippy-check.yml
@@ -14,5 +14,16 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
         with:
           components: clippy
+      - name: Cache cargo
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-rust-clippy-check
       - name: rust-clippy-check
         run: cargo +nightly clippy --all-targets --all-features --tests -- -Dwarnings

--- a/.github/workflows/rust-test-check.yml
+++ b/.github/workflows/rust-test-check.yml
@@ -21,7 +21,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-rust-test-check
+          key: ${{ runner.os }}-rust-test-check-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-rust-test-check-${{ hashFiles('**/Cargo.lock') }}
       - name: rust-test-check
         run: cargo +nightly test

--- a/.github/workflows/rust-test-check.yml
+++ b/.github/workflows/rust-test-check.yml
@@ -12,5 +12,16 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install nightly toolchain
         uses: dtolnay/rust-toolchain@nightly
+      - name: Cache cargo
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-rust-test-check
       - name: rust-test-check
         run: cargo +nightly test


### PR DESCRIPTION
- Add Cargo cache configuration to both Clippy and test workflows
- Use GitHub Actions cache to improve build and test performance
- Cache Cargo registry, index, and target directories
- Use runner OS and Cargo.lock hash as cache key